### PR TITLE
separate k8s components into master and worked. 

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -15,12 +15,15 @@ k8s_pki_cert_suffix: '.pem'
 k8s_install_dir : /usr/local/bin
 k8s_conf_dir: /etc/kubernetes
 k8s_dest_pki_dir: /etc/kubernetes/pki
-k8s_components:
+k8s_worker_components: 
+  - kubelet
+  - kube-proxy
+k8s_master_components:
   - kube-apiserver
   - kube-controller-manager
-  - kube-proxy
   - kube-scheduler
-  - kubelet
+
+k8s_master: True
 
 k8s_pod_cluster_cidr: 10.253.0.0/16
 k8s_service_cluster_ip_range: 10.254.0.0/16
@@ -37,7 +40,8 @@ k8s_admission_control:
 k8s_allow_priv: False
 
 k8s_network_iface: eth0
-
+k8s_public_ipv4: '{{ hostvars[inventory_hostname]["ansible_" + k8s_network_iface]["ipv4"]["address"]}}'
+k8s_apiserver_secure_address: '{{k8s_public_ipv4}}'
 k8s_apiserver_insecure_address: '127.0.0.1'
 k8s_apiserver_insecure_port: 8080
 k8s_apiserver_secure_port: 6443

--- a/tasks/systemd.yml
+++ b/tasks/systemd.yml
@@ -3,6 +3,7 @@
   become: yes
   become_user: root
   with_items: '{{k8s_components}}'
+  when: '{{k8s_master or item in k8s_worker_components}}' 
   register: k8s_service_modified
   template: >-
     src=services/{{item}}.service.j2
@@ -18,7 +19,7 @@
 - name: start services...
   become: yes
   become_user: root
-  when: '{{k8s_launch|default(True)}}'
+  when: '{{k8s_launch|default(True) and (k8s_master or item in k8s_worker_components)}}'
   with_items: '{{k8s_components}}'
   service: >-
     name={{item}}

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,5 +1,7 @@
 ---
 # vars file for kubernetes-cluster
+k8s_components: '{{k8s_worker_components + k8s_master_components}}'
+
 k8s_pki_key_file : '{{inventory_hostname}}{{k8s_pki_key_suffix}}'
 k8s_pki_key_src: '{{k8s_src_pki_dir}}/{{k8s_pki_key_file}}'
 k8s_pki_key_dest : '{{k8s_dest_pki_dir}}/{{k8s_pki_key_file}}'
@@ -15,8 +17,6 @@ k8s_pki_ca_cert_dest : '{{k8s_dest_pki_dir}}/{{k8s_pki_ca_file}}'
 k8s_etcd_prefix: '{% if k8s_secured %}https{% else %}http{% endif %}'
 k8s_etcd_servers: '{% for h in groups["etcd-master"] %}{{k8s_etcd_prefix}}://{{h}}:2379{% if not loop.last %},{% endif %}{% endfor %}'
 
-k8s_public_ipv4: '{{ hostvars[inventory_hostname]["ansible_" + k8s_network_iface]["ipv4"]["address"]}}'
-k8s_apiserver_secure_address: '{{k8s_public_ipv4}}'
 k8s_kubelet_address: '{{k8s_public_ipv4}}'
 k8s_kube_controller_manager_address: '{{k8s_public_ipv4}}'
 k8s_kube_proxy_address: '{{k8s_public_ipv4}}'


### PR DESCRIPTION
- Move k8s secure address to default so it can be overridden in playbook. The secure address will be the master address for the workers.
- Add k8s_master variable (defaulted to true). If creating a single cluster, it can be left with default value as the master node will also be the worker node. For multi node cluster, set k8s_master var in group_vars according to targeted master and worked nodes.