### PR TITLE
Fix service-account key & certs for kube-apiserver, kube-controller-manager

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -36,8 +36,8 @@ k8s_cluster_domain: 'cluster.local'
 k8s_admission_control:
   - NamespaceLifecycle
   - LimitRanger
-  - SecurityContextDeny
   - ServiceAccount
+  - DefaultStorageClass
   - ResourceQuota
 
 #k8s_kube_api_args: -a -b -c

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,16 +1,2 @@
 ---
 # handlers file for kubernetes-cluster
-- name: systemctl daemon-reload
-  become: yes
-  become_user: root
-  when: '{{k8s_launch|default(True)}}'
-  command: systemctl daemon-reload
-
-- name: restarting k8s services
-  become: yes
-  become_user: root
-  when: '{{k8s_launch|default(True)}}'
-  with_items: '{{k8s_components}}'
-  service:
-    name: '{{item}}'
-    state: restarted

--- a/tasks/conf.yml
+++ b/tasks/conf.yml
@@ -43,5 +43,3 @@
     owner: '{{k8s_user}}'
     group: '{{k8s_group}}'
     mode: '0644'
-  notify:
-    - restarting k8s services

--- a/tasks/pki.yml
+++ b/tasks/pki.yml
@@ -17,6 +17,8 @@
     - { f: '{{k8s_pki_cert_src}}', d: '{{k8s_pki_cert_dest}}', m: '0600'}
     - { f: '{{k8s_pki_ca_cert_src}}', d: '{{k8s_pki_ca_cert_dest}}', m: '0600' }
     - { f: '{{k8s_pki_ca_key_src}}', d: '{{k8s_pki_ca_key_dest}}', m: '0400' }
+    - { f: '{{k8s_pki_service_account_key_src}}', d: '{{k8s_pki_service_account_key_dest}}', m: '0400' }
+    - { f: '{{k8s_pki_service_account_cert_src}}', d: '{{k8s_pki_service_account_cert_dest}}', m: '0600'}
   copy:
     src: '{{item.f}}'
     dest: '{{item.d}}'

--- a/templates/addons/kube-dashboard.yml.j2
+++ b/templates/addons/kube-dashboard.yml.j2
@@ -31,6 +31,9 @@ spec:
       containers:
       - name: kubernetes-dashboard
         image: gcr.io/google_containers/kubernetes-dashboard-amd64:v1.5.1
+        args:
+          - --v={{k8s_log_level}}
+          - --logtostderr=true
         ports:
         - containerPort: 9090
           protocol: TCP
@@ -50,6 +53,7 @@ metadata:
     app: kubernetes-dashboard
     kubernetes.io/cluster-service: "true"
 spec:
+  type: NodePort
   selector:
     app: kubernetes-dashboard
   ports:

--- a/templates/addons/kube-dns-autoscaler.yml.j2
+++ b/templates/addons/kube-dns-autoscaler.yml.j2
@@ -42,4 +42,4 @@ spec:
           # If using small nodes, "nodesPerReplica" should dominate.
           - --default-params={"linear":{"coresPerReplica":256,"nodesPerReplica":16,"min":1}}
           - --logtostderr=true
-          - --v=2
+          - --v={{k8s_log_level}}

--- a/templates/addons/kube-dns.yml.j2
+++ b/templates/addons/kube-dns.yml.j2
@@ -70,7 +70,7 @@ spec:
         args:
         - --domain={{k8s_cluster_domain}}.
         - --dns-port=10053
-        - --v=2
+        - --v={{k8s_log_level}}
         ports:
         - containerPort: 10053
           name: dns-local
@@ -118,7 +118,7 @@ spec:
           successThreshold: 1
           failureThreshold: 5
         args:
-        - --v=2
+        - --v={{k8s_log_level}}
         - --logtostderr
         - --probe=kubedns,127.0.0.1:10053,kubernetes.default.svc.{{k8s_cluster_domain}},5,A
         - --probe=dnsmasq,127.0.0.1:53,kubernetes.default.svc.{{k8s_cluster_domain}},5,A

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -4,6 +4,8 @@ k8s_master: '{{ inventory_hostname in groups[k8s_master_group_name] }}'
 
 k8s_components: '{{ (k8s_master_components + k8s_worker_components) if k8s_master else k8s_worker_components }}'
 
+k8s_apiserver_first_master: '{{groups[k8s_master_group_name][0]}}'
+
 k8s_pki_key_file : '{{inventory_hostname}}{{k8s_pki_key_suffix}}'
 k8s_pki_key_src: '{{k8s_src_pki_dir}}/{{k8s_pki_key_file}}'
 k8s_pki_key_dest : '{{k8s_dest_pki_dir}}/{{k8s_pki_key_file}}'
@@ -19,6 +21,14 @@ k8s_pki_ca_cert_dest : '{{k8s_dest_pki_dir}}/{{k8s_pki_ca_file}}'
 k8s_pki_ca_key_src: '{{k8s_src_pki_dir}}/ca-key.pem'
 k8s_pki_ca_key_dest: '{{k8s_dest_pki_dir}}/ca-key.pem'
 
+k8s_pki_service_account_key_file: '{{k8s_apiserver_first_master}}{{k8s_pki_key_suffix}}'
+k8s_pki_service_account_key_src: '{{k8s_src_pki_dir}}/{{k8s_pki_service_account_key_file}}'
+k8s_pki_service_account_key_dest: '{{k8s_dest_pki_dir}}/k8s-service-account-key.pem'
+
+k8s_pki_service_account_cert_file: '{{k8s_apiserver_first_master}}{{k8s_pki_cert_suffix}}'
+k8s_pki_service_account_cert_src: '{{k8s_src_pki_dir}}/{{k8s_pki_service_account_cert_file}}'
+k8s_pki_service_account_cert_dest: '{{k8s_dest_pki_dir}}/k8s-service-account-cert.pem'
+
 k8s_etcd_prefix: '{% if k8s_secured %}https{% else %}http{% endif %}'
 k8s_etcd_servers: '{% for h in groups[k8s_etcd_master_group_name] %}{{k8s_etcd_prefix}}://{{h}}:2379{% if not loop.last %},{% endif %}{% endfor %}'
 
@@ -29,16 +39,16 @@ k8s_kube_proxy_address: '{{k8s_public_ipv4}}'
 k8s_kube_scheduler_address: '{{k8s_public_ipv4}}'
 
 k8s_apiserver_prefix: '{% if k8s_secured %}https{% else %}http{% endif %}'
-k8s_apiserver_storage_backend: '--storage-backend {{k8s_apiserver_etcd_backend}}'
-k8s_apiserver_etcd_tls: '{% if k8s_secured %}--etcd-cafile {{k8s_pki_ca_cert_dest}} --etcd-certfile {{k8s_pki_cert_dest}} --etcd-keyfile {{k8s_pki_key_dest}}{% endif %}'
-k8s_apiserver_tls: '{% if k8s_secured %}--tls-ca-file {{k8s_pki_ca_cert_dest}} --tls-cert-file {{k8s_pki_cert_dest}} --tls-private-key-file {{k8s_pki_key_dest}}{% endif %}'
-k8s_apiserver_kubelet_tls: '{% if k8s_secured %}--kubelet-https --kubelet-certificate-authority {{k8s_pki_ca_cert_dest}} --kubelet-client-certificate {{k8s_pki_cert_dest}} --kubelet-client-key {{k8s_pki_key_dest}}{% endif %}'
+k8s_apiserver_storage_backend: '--storage-backend={{k8s_apiserver_etcd_backend}}'
+k8s_apiserver_etcd_tls: '{% if k8s_secured %}--etcd-cafile={{k8s_pki_ca_cert_dest}} --etcd-certfile={{k8s_pki_cert_dest}} --etcd-keyfile={{k8s_pki_key_dest}}{% endif %}'
+k8s_apiserver_tls: '{% if k8s_secured %}--tls-ca-file={{k8s_pki_ca_cert_dest}} --tls-cert-file={{k8s_pki_cert_dest}} --tls-private-key-file={{k8s_pki_key_dest}}{% endif %}'
+k8s_apiserver_kubelet_tls: '{% if k8s_secured %}--kubelet-https=true --kubelet-certificate-authority={{k8s_pki_ca_cert_dest}} --kubelet-client-certificate={{k8s_pki_cert_dest}} --kubelet-client-key={{k8s_pki_key_dest}}{% endif %}'
 k8s_apiserver_token_auth: '--token_auth_file={{k8s_conf_dir}}/kube-apiserver-known-tokens.csv'
 k8s_apiserver_kat: '{% if k8s_apiserver_kubelet_address_types is defined %}--kubelet-preferred-address-types={{k8s_apiserver_kubelet_address_types | join(",")}}{% endif %}'
 k8s_apiserver_count: '--apiserver-count={{groups[k8s_master_group_name] | length | int}}'
-k8s_apiserver_args: '{{k8s_apiserver_storage_backend}} {{k8s_apiserver_etcd_tls}} {{k8s_apiserver_tls}} {{k8s_apiserver_kubelet_tls}} {{k8s_apiserver_token_auth}} {{k8s_apiserver_kat}} {{k8s_apiserver_count}}'
+k8s_apiserver_service_account_key: '{% if k8s_secured %}--service-account-key-file={{k8s_pki_service_account_cert_dest}}{% endif %}'
+k8s_apiserver_args: '{{k8s_apiserver_storage_backend}} {{k8s_apiserver_etcd_tls}} {{k8s_apiserver_tls}} {{k8s_apiserver_kubelet_tls}} {{k8s_apiserver_token_auth}} {{k8s_apiserver_kat}} {{k8s_apiserver_count}} {{k8s_apiserver_service_account_key}}'
 
-k8s_apiserver_first_master: '{{groups[k8s_master_group_name][0]}}'
 k8s_apiserver_secure_lb_eff: "{% if k8s_apiserver_secure_lb is defined %}{{k8s_apiserver_secure_lb}}{% else %}{{k8s_apiserver_prefix}}://{{hostvars[k8s_apiserver_first_master]['ansible_' + k8s_network_iface]['ipv4']['address']}}:{{k8s_apiserver_secure_port}}{% endif %}"
 
 k8s_kubelet_tls: '{% if k8s_secured %}--tls-cert-file {{k8s_pki_cert_dest}} --tls-private-key-file {{k8s_pki_key_dest}}{% endif %}'
@@ -55,7 +65,7 @@ k8s_kube_controller_manager_secured_args: >-
   --cluster-signing-cert-file={{k8s_pki_ca_cert_dest}}
   --cluster-signing-key-file={{k8s_pki_ca_key_dest}}
   --root-ca-file={{k8s_pki_ca_cert_dest}}
-  --service-account-private-key-file={{k8s_pki_key_dest}}
+  --service-account-private-key-file={{k8s_pki_service_account_key_dest}}
 
   
 k8s_kube_controller_manager_args: '{% if k8s_secured %}{{k8s_kube_controller_manager_secured_args}}{% endif %} --leader-elect=true'


### PR DESCRIPTION
Also includes
- k8s_admission_control updated based on https://kubernetes.io/docs/admin/admission-controllers/#is-there-a-recommended-set-of-plug-ins-to-use
- Removed the handlers in favor of register and when conditions

Fix based on kubernetes/kubernetes#11000